### PR TITLE
feat: scaffold microservices for alert RCA pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/config/ingest.yaml
+++ b/config/ingest.yaml
@@ -1,0 +1,35 @@
+service:
+  name: email-ingest
+  host: 0.0.0.0
+  port: 8001
+logging:
+  level: INFO
+  json: true
+mailboxes:
+  - type: imap
+    enabled: true
+    interval_seconds: 60
+    idle: true
+    imap_host: ${IMAP_HOST}
+    imap_port: 993
+    username: ${IMAP_USER}
+    password: ${IMAP_PASS}
+    folder: INBOX
+    search_filter: '(UNSEEN)'
+    rca_endpoint: http://orchestrator:8003/events
+  - type: msgraph
+    enabled: false
+    tenant_id: ${AZURE_TENANT_ID}
+    client_id: ${AZURE_CLIENT_ID}
+    client_secret: ${AZURE_CLIENT_SECRET}
+    user_id: ${GRAPH_USER_ID}
+    webhook_url: http://ingest:8001/msgraph/webhook
+    rca_endpoint: http://orchestrator:8003/events
+webhooks:
+  alertmanager:
+    enabled: true
+    rca_endpoint: http://orchestrator:8003/events
+    shared_secret: ${WEBHOOK_SHARED_SECRET}
+observability:
+  metrics_port: 9301
+  histogram_buckets: [0.1, 0.25, 0.5, 1.0, 2.0, 5.0]

--- a/config/orchestrator.yaml
+++ b/config/orchestrator.yaml
@@ -1,0 +1,23 @@
+service:
+  name: ops-orchestrator
+  host: 0.0.0.0
+  port: 8003
+logging:
+  level: INFO
+  json: true
+deduplication:
+  window_seconds: 300
+  cache_size: 1000
+approvals:
+  enabled: true
+  channel: slack
+  webhook: ${APPROVAL_WEBHOOK}
+rca_service:
+  base_url: http://rca:8002
+  timeout_seconds: 45
+policy_repository:
+  path: policies/remediation_policies.yaml
+  refresh_interval_seconds: 120
+observability:
+  metrics_port: 9303
+  histogram_buckets: [0.1, 0.25, 0.5, 1.0, 2.0, 5.0]

--- a/config/rca.yaml
+++ b/config/rca.yaml
@@ -1,0 +1,16 @@
+service:
+  name: qwen-rca
+  host: 0.0.0.0
+  port: 8002
+logging:
+  level: INFO
+  json: true
+qwen:
+  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model: qwen-plus
+  temperature: 0.1
+  api_key_env: QWEN_API_KEY
+  request_timeout_seconds: 30
+observability:
+  metrics_port: 9302
+  histogram_buckets: [0.1, 0.25, 0.5, 1.0, 2.0, 5.0]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.9"
+services:
+  ingest:
+    build:
+      context: .
+      dockerfile: docker/ingest.Dockerfile
+    ports:
+      - "8001:8001"
+    environment:
+      IMAP_HOST: imap.example.com
+      IMAP_USER: alerts@example.com
+      IMAP_PASS: change-me
+      WEBHOOK_SHARED_SECRET: dev-secret
+      RCA_ENDPOINT: http://orchestrator:8003/events
+    volumes:
+      - ./config:/app/config:ro
+      - ./services:/app/services:ro
+      - ./policies:/app/policies:ro
+    depends_on:
+      - orchestrator
+  rca:
+    build:
+      context: .
+      dockerfile: docker/rca.Dockerfile
+    environment:
+      QWEN_API_KEY: ${QWEN_API_KEY}
+    ports:
+      - "8002:8002"
+    volumes:
+      - ./config:/app/config:ro
+      - ./services:/app/services:ro
+  orchestrator:
+    build:
+      context: .
+      dockerfile: docker/orchestrator.Dockerfile
+    environment:
+      APPROVAL_WEBHOOK: https://hooks.slack.com/services/xxx
+    ports:
+      - "8003:8003"
+    volumes:
+      - ./config:/app/config:ro
+      - ./services:/app/services:ro
+      - ./policies:/app/policies:ro
+    depends_on:
+      - rca

--- a/docker/ingest.Dockerfile
+++ b/docker/ingest.Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        fastapi uvicorn[standard] httpx pydantic python-dotenv pyyaml structlog prometheus-client \
+        beautifulsoup4 imapclient
+COPY services ./services
+COPY config ./config
+COPY policies ./policies
+ENV PYTHONPATH=/app
+CMD ["uvicorn", "services.ingest.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker/orchestrator.Dockerfile
+++ b/docker/orchestrator.Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard] httpx pydantic python-dotenv pyyaml structlog prometheus-client
+COPY services ./services
+COPY config ./config
+COPY policies ./policies
+ENV PYTHONPATH=/app
+CMD ["uvicorn", "services.orchestrator.main:app", "--host", "0.0.0.0", "--port", "8003"]

--- a/docker/rca.Dockerfile
+++ b/docker/rca.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard] httpx pydantic python-dotenv pyyaml structlog prometheus-client
+COPY services ./services
+COPY config ./config
+ENV PYTHONPATH=/app
+CMD ["uvicorn", "services.rca.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,49 @@
+# AIOps Email RCA Runbook
+
+## Overview
+
+This runbook describes the minimal viable workflow described in the project README:
+
+1. **Email/Alert intake** via IMAP polling, Microsoft Graph subscriptions or Alertmanager webhooks.
+2. **Normalization** to the canonical event JSON schema.
+3. **Root Cause Analysis (RCA)** using the Qwen-Plus model exposed through the `rca` microservice.
+4. **Policy evaluation and action orchestration** handled by the `orchestrator` microservice.
+5. **Remediation** via REST tool integrations (`/tools/prom`, `/tools/k8s`, `/tools/es`, `/tools/netprobe`). Implementations of these tools are expected to be provided by downstream platform teams.
+
+## Microservice responsibilities
+
+| Service | Responsibility | Interfaces |
+| ------- | -------------- | ---------- |
+| `ingest` | Polls mailboxes, validates webhooks, transforms messages into events and forwards them to the orchestrator. | `POST /events/email`, `POST /webhook/alertmanager`, `POST /msgraph/webhook`, metrics exporter on port `9301`. |
+| `rca` | Wraps Qwen-Plus API with offline fallback. | `POST /rca`, metrics exporter on port `9302`. |
+| `orchestrator` | Deduplicates events, calls RCA service, maps decisions to remediation policies and tracks approvals. | `POST /events`, `POST /approvals/{id}`, `POST /policies/reload`, metrics exporter on port `9303`. |
+
+## Operating procedures
+
+### Configuration
+
+* Configuration is stored under the `config/` directory and mounted into each container read-only.
+* Environment-sensitive values (secrets, tenant identifiers, endpoints) are injected through environment variables and expanded at runtime.
+* Policy definitions live under `policies/` and are hot-reloaded every two minutes by default.
+
+### Deploying locally
+
+```bash
+docker compose up --build
+```
+
+Expose required environment variables prior to launching (e.g. `export QWEN_API_KEY=...`).
+
+### On-call checklist
+
+1. **Service health** – Verify `/healthz` endpoints and Prometheus metrics exporters (ports `9301-9303`).
+2. **Mailbox connectivity** – Ensure IMAP or Graph credentials are valid; check logs for `imap.poll.error` or `graph.payload` warnings.
+3. **RCA fallbacks** – If `QWEN_API_KEY` is missing, the RCA service will emit warnings and produce deterministic offline plans.
+4. **Policy approvals** – Monitor logs for `orchestrator.approval_required` entries and trigger approval via `POST /approvals/{request_id}`.
+5. **Knowledge base updates** – Persist RCA outcomes and policy actions into the organisation's knowledge base after incident closure.
+
+### Disaster recovery
+
+* The orchestrator deduplication cache prevents alert storms from overwhelming the RCA service; its TTL and capacity can be tuned in `config/orchestrator.yaml`.
+* Restarting services is safe; IMAP pollers resume from unseen messages and policies are reloaded at startup.
+* Ensure secrets are rotated regularly and stored in Vault/Kubernetes Secret resources.

--- a/policies/remediation_policies.yaml
+++ b/policies/remediation_policies.yaml
@@ -1,0 +1,65 @@
+# Remediation policy mapping from alert type to evidence gathering and actions
+prometheus_remote_write_behind:
+  severity: P2
+  evidence:
+    - type: promql
+      query: rate(prometheus_remote_storage_highest_timestamp_in_seconds[5m])
+      description: "Check remote write lag trend"
+    - type: log
+      target: prometheus
+      filter: "remote storage reshard"
+  diagnosis_rules:
+    - when: metrics.times >= 3
+      then: "Prometheus remote write has been lagging repeatedly"
+    - when: labels.cluster == "HK-DCE5-PLATFORM"
+      then: "Cluster specific SLA breach"
+  actions:
+    safe:
+      - type: k8s
+        verb: rollout-restart
+        resource: deployment/prometheus-agent
+      - type: prom
+        operation: silence
+        params:
+          duration: 15m
+          matchers:
+            - name: alertname
+              value: PrometheusRemoteWriteBehind
+    risky:
+      approval_required: true
+      steps:
+        - type: k8s
+          verb: delete-pod
+          resource: pod/prometheus-insight-agent-kube-prometh-prometheus-0
+  rollback:
+    - type: k8s
+      verb: rollout-undo
+      resource: deployment/prometheus-agent
+jenkins_master_restarted:
+  severity: P3
+  evidence:
+    - type: http
+      endpoint: http://jenkins.example.com/login
+      description: "Verify Jenkins UI availability"
+  actions:
+    safe:
+      - type: slack
+        message: "Jenkins master restarted; verifying pipeline backlogs"
+  rollback: []
+vmalert_config_sync_failed:
+  severity: P2
+  evidence:
+    - type: promql
+      query: rate(vmalert_config_last_reload_successful[5m])
+      description: "Monitor last reload status"
+  actions:
+    safe:
+      - type: vm
+        operation: config-reload
+        params:
+          instance: vmalert-prod-0
+  rollback:
+    - type: vm
+      operation: config-rollback
+      params:
+        version: previous

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "alert-analysis-llm"
+version = "0.1.0"
+description = "Microservices reference implementation for automated alert RCA"
+authors = [{name = "AIOps Team"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.24",
+    "httpx>=0.27",
+    "pydantic>=1.10",
+    "python-dotenv>=1.0",
+    "pyyaml>=6.0",
+    "structlog>=24.1",
+    "prometheus-client>=0.19",
+    "beautifulsoup4>=4.12",
+    "imapclient>=3.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23"
+]
+
+[tool.ruff]
+line-length = 100

--- a/services/common/config.py
+++ b/services/common/config.py
@@ -1,0 +1,41 @@
+"""Utility helpers for loading YAML configuration with environment overrides."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class ConfigLoader:
+    """Loads configuration files and expands environment variables."""
+
+    base_dir: Path
+
+    def load(self, relative_path: str) -> Dict[str, Any]:
+        path = self.base_dir / relative_path
+        if not path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        return self._expand_env(data)
+
+    def _expand_env(self, node: Any) -> Any:
+        if isinstance(node, dict):
+            return {key: self._expand_env(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [self._expand_env(item) for item in node]
+        if isinstance(node, str):
+            return os.path.expandvars(node)
+        return node
+
+
+def load_config(relative_path: str) -> Dict[str, Any]:
+    """Convenience wrapper that assumes the repository root as base directory."""
+
+    base = Path(__file__).resolve().parents[2]
+    loader = ConfigLoader(base)
+    return loader.load(relative_path)

--- a/services/common/logging.py
+++ b/services/common/logging.py
@@ -1,0 +1,29 @@
+"""Structured logging helpers based on structlog."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import structlog
+
+
+def configure_logging(level: str = "INFO", json_mode: bool = True) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    processors: list[Any] = [
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+    if json_mode:
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer(colors=True))
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(
+            getattr(logging, level.upper(), logging.INFO)
+        ),
+        cache_logger_on_first_use=True,
+    )

--- a/services/common/metrics.py
+++ b/services/common/metrics.py
@@ -1,0 +1,23 @@
+"""Prometheus metrics utilities."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from prometheus_client import Counter, Histogram, start_http_server
+
+
+class MetricsRegistry:
+    def __init__(self, buckets: Iterable[float]):
+        self.processing_latency = Histogram(
+            "service_processing_latency_seconds",
+            "Latency for processing RCA pipeline stages",
+            buckets=tuple(buckets),
+        )
+        self.processed_events = Counter(
+            "service_processed_events_total",
+            "Number of events processed by the service",
+            ["status"],
+        )
+
+    def start_exporter(self, port: int) -> None:
+        start_http_server(port)

--- a/services/common/models.py
+++ b/services/common/models.py
@@ -1,0 +1,61 @@
+"""Pydantic models shared across services."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, root_validator
+
+
+class AlertLabels(BaseModel):
+    cluster: Optional[str]
+    namespace: Optional[str]
+    workload: Optional[str]
+    component: Optional[str]
+    environment: Optional[str] = None
+
+
+class AlertMetrics(BaseModel):
+    times: int = Field(..., ge=0)
+    first_occur: Optional[datetime]
+
+
+class RawEventMetadata(BaseModel):
+    mail_subject: Optional[str]
+    mail_id: Optional[str]
+    source: Optional[str]
+    payload: Optional[Dict[str, Any]]
+
+
+class Event(BaseModel):
+    alert: str
+    severity: str
+    labels: AlertLabels
+    metrics: AlertMetrics
+    raw: RawEventMetadata = Field(default_factory=RawEventMetadata)
+
+    @root_validator
+    def normalize_alert_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        alert = values.get("alert")
+        if alert:
+            values["alert"] = alert.strip()
+        severity = values.get("severity")
+        if severity:
+            values["severity"] = severity.upper()
+        return values
+
+
+class RCAResponse(BaseModel):
+    evidence_plan: Any
+    diagnosis: Any
+    actions: Any
+    rollback: Any
+    raw_response: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PolicyDecision(BaseModel):
+    event: Event
+    rca: RCAResponse
+    approved: bool
+    actions_to_execute: Dict[str, Any]
+    notes: Optional[str]

--- a/services/ingest/email_parser.py
+++ b/services/ingest/email_parser.py
@@ -1,0 +1,73 @@
+"""Utilities to parse alert emails into the canonical event JSON schema."""
+from __future__ import annotations
+
+import json
+from typing import Iterable, List
+
+from bs4 import BeautifulSoup
+
+from services.common.models import AlertLabels, AlertMetrics, Event, RawEventMetadata
+
+
+class EmailParser:
+    def __init__(self, default_severity: str = "P3"):
+        self.default_severity = default_severity
+
+    def parse(self, raw_body: str, metadata: RawEventMetadata) -> List[Event]:
+        candidates = list(self._parse_html_tables(raw_body, metadata))
+        if candidates:
+            return candidates
+        return [
+            Event(
+                alert=metadata.payload.get("subject", "UnknownAlert"),
+                severity=self.default_severity,
+                labels=AlertLabels(**metadata.payload.get("labels", {})),
+                metrics=AlertMetrics(**metadata.payload.get("metrics", {"times": 1})),
+                raw=metadata,
+            )
+        ]
+
+    def _parse_html_tables(
+        self, raw_body: str, metadata: RawEventMetadata
+    ) -> Iterable[Event]:  # pragma: no cover - heuristics
+        soup = BeautifulSoup(raw_body, "html.parser")
+        for table in soup.find_all("table"):
+            headers = [th.get_text(strip=True).lower() for th in table.find_all("th")]
+            rows = table.find_all("tr")
+            for row in rows[1:]:
+                cells = [td.get_text(strip=True) for td in row.find_all("td")]
+                if not cells:
+                    continue
+                record = dict(zip(headers, cells))
+                labels = {
+                    "cluster": record.get("cluster"),
+                    "namespace": record.get("namespace"),
+                    "workload": record.get("workload"),
+                    "component": record.get("component"),
+                }
+                metrics = {
+                    "times": int(record.get("times", 1)),
+                    "first_occur": record.get("first_occur"),
+                }
+                yield Event(
+                    alert=record.get("alert", metadata.mail_subject or "UnknownAlert"),
+                    severity=record.get("severity", self.default_severity),
+                    labels=AlertLabels(**labels),
+                    metrics=AlertMetrics(**metrics),
+                    raw=metadata,
+                )
+
+    def parse_json_attachment(self, payload: str, metadata: RawEventMetadata) -> List[Event]:
+        data = json.loads(payload)
+        if isinstance(data, list):
+            return [self._from_json_blob(item, metadata) for item in data]
+        return [self._from_json_blob(data, metadata)]
+
+    def _from_json_blob(self, data: dict, metadata: RawEventMetadata) -> Event:
+        return Event(
+            alert=data.get("alert", metadata.mail_subject or "UnknownAlert"),
+            severity=data.get("severity", self.default_severity),
+            labels=AlertLabels(**data.get("labels", {})),
+            metrics=AlertMetrics(**data.get("metrics", {"times": 1})),
+            raw=metadata,
+        )

--- a/services/ingest/imap_worker.py
+++ b/services/ingest/imap_worker.py
@@ -1,0 +1,70 @@
+"""IMAP polling worker for converting alert emails into events."""
+from __future__ import annotations
+
+import email
+import imaplib
+import time
+from typing import Dict, Iterable, List
+
+import structlog
+
+from services.common.models import Event, RawEventMetadata
+from services.ingest.email_parser import EmailParser
+
+logger = structlog.get_logger(__name__)
+
+
+class IMAPPoller:
+    def __init__(self, config: Dict[str, str], parser: EmailParser):
+        self.config = config
+        self.parser = parser
+
+    def run_once(self) -> List[Event]:
+        logger.info("imap.poll.start", host=self.config.get("imap_host"))
+        with imaplib.IMAP4_SSL(self.config["imap_host"], int(self.config.get("imap_port", 993))) as client:
+            client.login(self.config["username"], self.config["password"])
+            client.select(self.config.get("folder", "INBOX"))
+            typ, data = client.search(None, self.config.get("search_filter", "ALL"))
+            events: List[Event] = []
+            for num in data[0].split():
+                typ, msg_data = client.fetch(num, "(RFC822)")
+                if typ != "OK":
+                    logger.warning("imap.fetch.failed", status=typ)
+                    continue
+                message = email.message_from_bytes(msg_data[0][1])
+                events.extend(self._handle_message(message))
+                client.store(num, "+FLAGS", "(\\Seen)")
+            logger.info("imap.poll.done", events=len(events))
+            return events
+
+    def poll_forever(self, callback) -> None:  # pragma: no cover - long running
+        interval = int(self.config.get("interval_seconds", 60))
+        while True:
+            try:
+                events = self.run_once()
+                for event in events:
+                    callback(event)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("imap.poll.error", error=str(exc))
+            time.sleep(interval)
+
+    def _handle_message(self, message) -> Iterable[Event]:
+        metadata = RawEventMetadata(
+            mail_subject=message.get("Subject"),
+            mail_id=message.get("Message-Id"),
+            source="imap",
+            payload={"subject": message.get("Subject")},
+        )
+        for part in message.walk():
+            content_type = part.get_content_type()
+            if content_type == "text/html":
+                body = part.get_payload(decode=True).decode(errors="ignore")
+                yield from self.parser.parse(body, metadata)
+                return
+            if content_type == "application/json":
+                payload = part.get_payload(decode=True).decode(errors="ignore")
+                yield from self.parser.parse_json_attachment(payload, metadata)
+                return
+        if message.get_content_type() == "text/plain":
+            body = message.get_payload(decode=True).decode(errors="ignore")
+            yield from self.parser.parse(body, metadata)

--- a/services/ingest/main.py
+++ b/services/ingest/main.py
@@ -1,0 +1,112 @@
+"""Email ingest microservice exposing HTTP endpoints for alert normalization."""
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import threading
+from hashlib import sha256
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+import structlog
+
+from services.common.config import load_config
+from services.common.logging import configure_logging
+from services.common.metrics import MetricsRegistry
+from services.common.models import Event, RawEventMetadata
+from services.ingest.email_parser import EmailParser
+from services.ingest.imap_worker import IMAPPoller
+from services.ingest.msgraph_worker import GraphIngestor
+
+CONFIG = load_config("config/ingest.yaml")
+configure_logging(CONFIG.get("logging", {}).get("level", "INFO"), CONFIG.get("logging", {}).get("json", True))
+logger = structlog.get_logger(__name__)
+metrics = MetricsRegistry(CONFIG.get("observability", {}).get("histogram_buckets", [0.1, 0.5, 1.0]))
+metrics.start_exporter(CONFIG.get("observability", {}).get("metrics_port", 9301))
+
+app = FastAPI(title="Email Ingest Service", version="0.1.0")
+parser = EmailParser()
+
+
+async def push_event(event: Event) -> None:
+    endpoint = CONFIG["webhooks"]["alertmanager"]["rca_endpoint"]
+    logger.info("ingest.forward", endpoint=endpoint, alert=event.alert)
+    metrics.processed_events.labels(status="processed").inc()
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(endpoint, json=json.loads(event.json()))
+        response.raise_for_status()
+
+
+def start_imap_pollers():  # pragma: no cover - background threads
+    for mailbox in CONFIG.get("mailboxes", []):
+        if mailbox.get("type") != "imap" or not mailbox.get("enabled", False):
+            continue
+        poller = IMAPPoller(mailbox, parser)
+
+        def callback(event: Event) -> None:
+            asyncio.run(push_event(event))
+
+        thread = threading.Thread(target=poller.poll_forever, args=(callback,), daemon=True)
+        thread.start()
+        logger.info("imap.poller.started", mailbox=mailbox.get("username"))
+
+
+@app.on_event("startup")
+async def startup_event() -> None:  # pragma: no cover - runtime hook
+    logger.info("ingest.startup")
+    start_imap_pollers()
+
+
+@app.post("/events/email")
+async def ingest_email(payload: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = RawEventMetadata(
+        mail_subject=payload.get("subject"),
+        mail_id=payload.get("message_id"),
+        source=payload.get("source", "api"),
+        payload=payload,
+    )
+    events = parser.parse(payload.get("body", ""), metadata)
+    for event in events:
+        await push_event(event)
+    return {"accepted": len(events)}
+
+
+@app.post("/webhook/alertmanager")
+async def alertmanager_webhook(request: Request, background_tasks: BackgroundTasks):
+    secret = CONFIG["webhooks"]["alertmanager"].get("shared_secret")
+    if secret:
+        signature = request.headers.get("X-Signature")
+        body = await request.body()
+        expected = hmac.new(secret.encode(), body, sha256).hexdigest()
+        if signature != expected:
+            raise HTTPException(status_code=401, detail="signature mismatch")
+        payload = json.loads(body)
+    else:
+        payload = await request.json()
+    event = Event.parse_obj(payload)
+    background_tasks.add_task(push_event, event)
+    return {"status": "queued"}
+
+
+@app.post("/msgraph/webhook")
+async def msgraph_webhook(request: Request):
+    params = dict(request.query_params)
+    if "validationToken" in params:
+        logger.info("msgraph.validation")
+        return JSONResponse(content=params["validationToken"])
+    payload = await request.json()
+    ingestor = GraphIngestor(CONFIG["mailboxes"][1], parser)
+    events: List[Event] = []
+    for notification in payload.get("value", []):
+        events.extend(ingestor.fetch_incremental(notification))
+    for event in events:
+        await push_event(event)
+    return {"processed": len(events)}
+
+
+@app.get("/healthz")
+async def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}

--- a/services/ingest/msgraph_worker.py
+++ b/services/ingest/msgraph_worker.py
@@ -1,0 +1,59 @@
+"""Microsoft Graph subscription utilities."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List
+
+import httpx
+import structlog
+
+from services.common.models import Event, RawEventMetadata
+from services.ingest.email_parser import EmailParser
+
+logger = structlog.get_logger(__name__)
+
+
+class GraphIngestor:
+    def __init__(self, config: Dict[str, Any], parser: EmailParser):
+        self.config = config
+        self.parser = parser
+        self.client = httpx.Client(timeout=30)
+
+    def fetch_incremental(self, subscription_payload: Dict[str, Any]) -> List[Event]:
+        resource_id = subscription_payload.get("resourceData", {}).get("id")
+        if not resource_id:
+            logger.warning("graph.payload.missing_id", payload=subscription_payload)
+            return []
+        token = self._acquire_token()
+        url = f"https://graph.microsoft.com/v1.0/users/{self.config['user_id']}/messages/{resource_id}"
+        response = self.client.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        message = response.json()
+        metadata = RawEventMetadata(
+            mail_subject=message.get("subject"),
+            mail_id=message.get("id"),
+            source="msgraph",
+            payload={"subject": message.get("subject")},
+        )
+        body = message.get("body", {}).get("content", "")
+        return self.parser.parse(body, metadata)
+
+    def _acquire_token(self) -> str:  # pragma: no cover - external call
+        tenant = self.config["tenant_id"]
+        token_url = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+        data = {
+            "client_id": self.config["client_id"],
+            "client_secret": self.config["client_secret"],
+            "scope": "https://graph.microsoft.com/.default",
+            "grant_type": "client_credentials",
+        }
+        response = self.client.post(token_url, data=data)
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+    def handle_validation(self, token: str) -> Dict[str, Any]:
+        logger.info("graph.validation", token=token)
+        return {"validationToken": token}

--- a/services/orchestrator/cache.py
+++ b/services/orchestrator/cache.py
@@ -1,0 +1,38 @@
+"""Simple TTL cache for deduplication."""
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Optional, Tuple
+
+
+@dataclass
+class CacheItem:
+    key: str
+    timestamp: float
+
+
+class DeduplicationCache:
+    def __init__(self, ttl_seconds: int, max_size: int):
+        self.ttl = ttl_seconds
+        self.max_size = max_size
+        self.queue: Deque[CacheItem] = deque()
+        self.index: Dict[str, float] = {}
+
+    def add(self, key: str) -> bool:
+        now = time.time()
+        self._evict(now)
+        if key in self.index:
+            return False
+        self.index[key] = now
+        self.queue.append(CacheItem(key, now))
+        if len(self.queue) > self.max_size:
+            old = self.queue.popleft()
+            self.index.pop(old.key, None)
+        return True
+
+    def _evict(self, now: float) -> None:
+        while self.queue and now - self.queue[0].timestamp > self.ttl:
+            old = self.queue.popleft()
+            self.index.pop(old.key, None)

--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -1,0 +1,111 @@
+"""Orchestrator service coordinating RCA and remediation policies."""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from pathlib import Path
+from typing import Dict
+
+import httpx
+from fastapi import BackgroundTasks, FastAPI, HTTPException
+import structlog
+
+from services.common.config import load_config
+from services.common.logging import configure_logging
+from services.common.metrics import MetricsRegistry
+from services.common.models import Event, PolicyDecision, RCAResponse
+from services.orchestrator.cache import DeduplicationCache
+from services.orchestrator.policy import PolicyEngine, PolicyRepository
+
+CONFIG = load_config("config/orchestrator.yaml")
+configure_logging(CONFIG.get("logging", {}).get("level", "INFO"), CONFIG.get("logging", {}).get("json", True))
+logger = structlog.get_logger(__name__)
+metrics = MetricsRegistry(CONFIG.get("observability", {}).get("histogram_buckets", [0.1, 0.5, 1.0]))
+metrics.start_exporter(CONFIG.get("observability", {}).get("metrics_port", 9303))
+
+app = FastAPI(title="Ops Orchestrator", version="0.1.0")
+cache = DeduplicationCache(
+    ttl_seconds=CONFIG.get("deduplication", {}).get("window_seconds", 300),
+    max_size=CONFIG.get("deduplication", {}).get("cache_size", 1000),
+)
+policy_repo = PolicyRepository(Path(CONFIG["policy_repository"]["path"]))
+policy_engine = PolicyEngine(policy_repo)
+pending_approvals: Dict[str, PolicyDecision] = {}
+
+
+async def call_rca_service(event: Event) -> RCAResponse:
+    payload = {
+        "model": "qwen-plus",
+        "messages": [
+            {"role": "system", "content": "你是SRE助手，严格输出JSON: evidence_plan, diagnosis, actions, rollback"},
+            {"role": "user", "content": json.dumps(event.dict(), ensure_ascii=False)},
+        ],
+        "temperature": 0.1,
+    }
+    base_url = CONFIG["rca_service"]["base_url"].rstrip("/")
+    async with httpx.AsyncClient(
+        timeout=CONFIG.get("rca_service", {}).get("timeout_seconds", 45)
+    ) as client:
+        response = await client.post(f"{base_url}/rca", json=payload)
+        response.raise_for_status()
+        data = response.json()
+    return RCAResponse.parse_obj(data)
+
+
+async def process_event(event: Event) -> PolicyDecision:
+    rca = await call_rca_service(event)
+    decision = policy_engine.evaluate(event, rca)
+    if not decision.approved:
+        request_id = str(uuid.uuid4())
+        pending_approvals[request_id] = decision
+        logger.info("orchestrator.approval_required", request_id=request_id, alert=event.alert)
+    else:
+        logger.info("orchestrator.approved", alert=event.alert)
+    return decision
+
+
+@app.on_event("startup")
+async def startup_event() -> None:  # pragma: no cover - runtime hook
+    logger.info("orchestrator.startup")
+    asyncio.create_task(_policy_refresh_loop())
+
+
+async def _policy_refresh_loop():  # pragma: no cover - runtime hook
+    interval = CONFIG["policy_repository"].get("refresh_interval_seconds", 120)
+    while True:
+        await asyncio.sleep(interval)
+        policy_engine.refresh()
+        logger.info("policy.refreshed")
+
+
+@app.post("/events")
+async def receive_event(event: Event, background_tasks: BackgroundTasks):
+    fingerprint = f"{event.alert}:{event.labels.cluster}:{event.metrics.first_occur}"
+    if not cache.add(fingerprint):
+        metrics.processed_events.labels(status="duplicate").inc()
+        return {"status": "duplicate"}
+    metrics.processed_events.labels(status="accepted").inc()
+    background_tasks.add_task(process_event, event)
+    return {"status": "queued"}
+
+
+@app.post("/approvals/{request_id}")
+async def approve(request_id: str):
+    decision = pending_approvals.get(request_id)
+    if not decision:
+        raise HTTPException(status_code=404, detail="request not found")
+    decision.approved = True
+    logger.info("approval.granted", request_id=request_id)
+    return {"status": "approved", "actions": decision.actions_to_execute}
+
+
+@app.post("/policies/reload")
+async def reload_policies():
+    policy_engine.refresh()
+    return {"status": "reloaded"}
+
+
+@app.get("/healthz")
+async def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}

--- a/services/orchestrator/policy.py
+++ b/services/orchestrator/policy.py
@@ -1,0 +1,97 @@
+"""Policy evaluation utilities."""
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from services.common.models import Event, PolicyDecision, RCAResponse
+
+
+OPERATORS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">": operator.gt,
+    ">=": operator.ge,
+    "<": operator.lt,
+    "<=": operator.le,
+}
+
+
+def _resolve_path(event: Event, path: str) -> Any:
+    node: Any = event.dict()
+    for part in path.split('.'):
+        node = node.get(part)
+        if node is None:
+            return None
+    return node
+
+
+@dataclass
+class PolicyRepository:
+    path: Path
+
+    def load(self) -> Dict[str, Any]:
+        with self.path.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+
+
+class PolicyEngine:
+    def __init__(self, repository: PolicyRepository):
+        self.repository = repository
+        self._policies = self.repository.load()
+
+    def refresh(self) -> None:
+        self._policies = self.repository.load()
+
+    def evaluate(self, event: Event, rca: RCAResponse) -> PolicyDecision:
+        policy = self._policies.get(event.alert.lower())
+        if not policy:
+            return PolicyDecision(
+                event=event,
+                rca=rca,
+                approved=False,
+                actions_to_execute={},
+                notes="No policy found",
+            )
+        notes = []
+        for rule in policy.get("diagnosis_rules", []):
+            condition = rule.get("when", "")
+            if not condition:
+                continue
+            lhs, op_symbol, rhs = self._parse_condition(condition)
+            lhs_value = _resolve_path(event, lhs)
+            rhs_value = self._coerce(rhs)
+            if op_symbol(lhs_value, rhs_value):
+                notes.append(rule.get("then"))
+        requires_approval = policy.get("actions", {}).get("risky", {}).get("approval_required", False)
+        approved = not requires_approval
+        actions = {
+            "safe": policy.get("actions", {}).get("safe", []),
+        }
+        if approved:
+            actions["risky"] = policy.get("actions", {}).get("risky", {}).get("steps", [])
+        return PolicyDecision(
+            event=event,
+            rca=rca,
+            approved=approved,
+            actions_to_execute=actions,
+            notes="; ".join(filter(None, notes)) or None,
+        )
+
+    def _parse_condition(self, condition: str):
+        for symbol, op in OPERATORS.items():
+            if symbol in condition:
+                lhs, rhs = condition.split(symbol, 1)
+                return lhs.strip(), op, rhs.strip().strip('"')
+        raise ValueError(f"Unsupported condition: {condition}")
+
+    def _coerce(self, value: str):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        return value

--- a/services/rca/client.py
+++ b/services/rca/client.py
@@ -1,0 +1,72 @@
+"""Client for interacting with Qwen RCA model."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import httpx
+import structlog
+
+from services.common.models import Event, RCAResponse
+
+logger = structlog.get_logger(__name__)
+
+
+class QwenClient:
+    def __init__(self, config: Dict[str, Any]):
+        self.base_url = config["base_url"].rstrip("/")
+        self.model = config.get("model", "qwen-plus")
+        self.temperature = config.get("temperature", 0.1)
+        self.timeout = config.get("request_timeout_seconds", 30)
+        api_key_env = config.get("api_key_env", "QWEN_API_KEY")
+        self.api_key = os.getenv(api_key_env)
+
+    async def rca(self, event: Event) -> RCAResponse:
+        if not self.api_key:
+            logger.warning("qwen.api_key.missing")
+            return self._offline_rca(event)
+        payload = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "你是SRE助手，严格输出JSON: evidence_plan, diagnosis, actions, rollback",
+                },
+                {"role": "user", "content": json.dumps(event.dict(), ensure_ascii=False)},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout) as client:
+            response = await client.post("/chat/completions", json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("qwen.parse_failed", content=content)
+            parsed = {
+                "evidence_plan": [],
+                "diagnosis": "Unable to parse model output",
+                "actions": [],
+                "rollback": [],
+            }
+        return RCAResponse(**parsed, raw_response=data)
+
+    def _offline_rca(self, event: Event) -> RCAResponse:
+        notes = {
+            "PrometheusRemoteWriteBehind": "Check remote write lag and agent health",
+            "JenkinsMasterRestarted": "Ensure Jenkins agents reconnect",
+        }
+        return RCAResponse(
+            evidence_plan=[{"step": "Check dashboards", "alert": event.alert}],
+            diagnosis=notes.get(event.alert, "Manual investigation required"),
+            actions=[{"type": "noop", "reason": "offline-mode"}],
+            rollback=[],
+            raw_response={},
+        )

--- a/services/rca/main.py
+++ b/services/rca/main.py
@@ -1,0 +1,46 @@
+"""RCA microservice that proxies requests to Qwen."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import FastAPI
+import structlog
+
+from services.common.config import load_config
+from services.common.logging import configure_logging
+from services.common.metrics import MetricsRegistry
+from services.common.models import Event, RCAResponse
+from services.rca.client import QwenClient
+
+CONFIG = load_config("config/rca.yaml")
+configure_logging(CONFIG.get("logging", {}).get("level", "INFO"), CONFIG.get("logging", {}).get("json", True))
+logger = structlog.get_logger(__name__)
+metrics = MetricsRegistry(CONFIG.get("observability", {}).get("histogram_buckets", [0.1, 0.5, 1.0]))
+metrics.start_exporter(CONFIG.get("observability", {}).get("metrics_port", 9302))
+
+app = FastAPI(title="Qwen RCA Service", version="0.1.0")
+client = QwenClient(CONFIG["qwen"])
+
+
+@app.post("/rca")
+async def rca_endpoint(payload: Dict[str, Any]) -> Dict[str, Any]:
+    user_message = next(
+        (msg for msg in payload.get("messages", []) if msg.get("role") == "user"),
+        None,
+    )
+    if not user_message:
+        return {"error": "missing user message"}
+    event_data = user_message.get("content")
+    if isinstance(event_data, str):
+        event_dict = Event.parse_raw(event_data).dict()
+    else:
+        event_dict = event_data
+    event = Event.parse_obj(event_dict)
+    metrics.processed_events.labels(status="accepted").inc()
+    response = await client.rca(event)
+    return response.dict()
+
+
+@app.get("/healthz")
+async def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- introduce FastAPI microservices for ingest, RCA proxy, and orchestration aligned with the email-to-remediation flow
- externalize configuration and remediation policies into dedicated YAML files with environment variable expansion
- add docker compose setup, Dockerfiles, and runbook documentation for deploying the reference pipeline

## Testing
- python -m compileall services

------
https://chatgpt.com/codex/tasks/task_e_68d8fce19ee88321aebf532545eab8bd